### PR TITLE
add homework kubernetes-controllers

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      nodeSelector:
+         homework: "true"
+      initContainers:
+        - name: init-mycontainer
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - wget https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ -O /init/index.html
+          volumeMounts:
+            - name: homework-vol
+              mountPath: /init
+      containers:
+        - name: nginx
+          image: nginx:1.25
+          ports:
+            - containerPort: 8000
+          command:
+            - sh
+            - -c
+            - |
+              cat > /etc/nginx/nginx.conf <<'EOF'
+              events {}
+              http {
+                server {
+                  listen 8000;
+                  server_name _;
+                  location / {
+                    root /homework;
+                    index index.html;
+                  }
+                }
+              }
+              EOF
+              nginx -g 'daemon off;'
+          volumeMounts:
+            - name: homework-vol
+              mountPath: /homework
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - rm -rf /homework/index.html
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /homework/index.html
+            initialDelaySeconds: 50
+            periodSeconds: 50
+      volumes:
+        - name: homework-vol
+          emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework


### PR DESCRIPTION
# Выполнено ДЗ № 3

 - [ V] Основное ДЗ
 - [ V] Задание со *

## В процессе сделано:
 - создан манифест deployment c 3 репликациями
 - со ограничением по ноде 
 - с пробой readiness 
 - с стратегией RollingUpdate недоступность 1 под 

## Как запустить проект:
 - создать дополнительно 1 ноду
  minikube node add
 - проверить что node 2штуки 
 minikube node list
- добавить лейбл ноде 
kubectl label node minikube homework=true
- зайти в папку kubernetes-controlles и применить манифесты
kubectl apply -f  namespace.yaml
kubectl apply -f deployment.yaml 


## Как проверить работоспособность:
- увидеть что Поды запущены только на одной ноде
kubectl  get pods -n homework -o wide
- зайте в первую node (имя ноды будет другое)
kubectl exec nginx-deployment-6c679d4774-fmjgm -n homework -i -t   -- bash
- проверить то что страница отдалаётся 
curl localhost:8000
## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
